### PR TITLE
Fix Navigation

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ module.exports = {
     Drawer: Layout.Drawer,
     HeaderRow: Layout.HeaderRow,
     HeaderTabs: Layout.HeaderTabs,
+    Navigation: Layout.Navigation,
     Content: Layout.Content,
     Menu: Menu.default,
     MenuItem: Menu.MenuItem,

--- a/src/layout/Drawer.js
+++ b/src/layout/Drawer.js
@@ -1,6 +1,5 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
-import Navigation from './Navigation';
 
 class Drawer extends React.Component {
     static propTypes = {
@@ -16,9 +15,7 @@ class Drawer extends React.Component {
         return (
             <div className={classes} {...otherProps}>
                 {title ? <span className="mdl-layout-title">{title}</span> : null}
-                <Navigation>
-                    {this.props.children}
-                </Navigation>
+                {this.props.children}
             </div>
         );
     }

--- a/src/layout/HeaderRow.js
+++ b/src/layout/HeaderRow.js
@@ -1,22 +1,10 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
-import Navigation from './Navigation';
 
 class HeaderRow extends React.Component {
     static propTypes = {
         className: PropTypes.string,
         title: PropTypes.string
-    }
-
-    _renderNav() {
-        var hasChildren = React.Children.count(this.props.children);
-        if(!hasChildren) return;
-
-        return (
-            <Navigation>
-                {this.props.children}
-            </Navigation>
-        );
     }
 
     render() {
@@ -28,7 +16,7 @@ class HeaderRow extends React.Component {
             <div className={classes} {...otherProps}>
                 {title ? <span className="mdl-layout-title">{title}</span> : null}
                 <div className="mdl-layout-spacer"></div>
-                {this._renderNav()}
+                {this.props.children}
             </div>
         );
     }

--- a/src/layout/Layout.js
+++ b/src/layout/Layout.js
@@ -32,5 +32,6 @@ export default mdlUpgrade(Layout);
 export Header from './Header';
 export Drawer from './Drawer';
 export HeaderRow from './HeaderRow';
+export Navigation from './Navigation';
 export HeaderTabs from './HeaderTabs';
 export var Content = basicClassCreator('mdl-layout__content', 'main');

--- a/src/layout/Navigation.js
+++ b/src/layout/Navigation.js
@@ -3,12 +3,12 @@ import classNames from 'classnames';
 import cloneChildren from '../utils/cloneChildren';
 
 class Navigation extends React.Component {
-	static propTypes = {
+    static propTypes = {
         className: PropTypes.string
     }
 
     render() {
-    	var { className, ...otherProps } = this.props;
+        var { className, ...otherProps } = this.props;
 
         var classes = classNames('mdl-navigation', className);
 

--- a/src/layout/Navigation.js
+++ b/src/layout/Navigation.js
@@ -1,11 +1,19 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import cloneChildren from '../utils/cloneChildren';
 
 class Navigation extends React.Component {
+	static propTypes = {
+        className: PropTypes.string
+    }
+
     render() {
+    	var { className, ...otherProps } = this.props;
+
+        var classes = classNames('mdl-navigation', className);
+
         return (
-            <nav className="mdl-navigation">
+            <nav className={classes} {...otherProps}>
                 {cloneChildren(this.props.children, (child) => ({
                     className: classNames('mdl-navigation__link', child.props.className)
                 }))}


### PR DESCRIPTION
The component [HeaderRow] children forced to wrapped to the [Navigation], it is bad because I can not correctly embed [Button], my solution replace {this._renderNav ()} to {this.props.children}