### PR TITLE
Unstrict React 0.14 peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "webpack-dev-server": "^1.10.1"
   },
   "peerDependencies": {
-    "react": "0.13.x || 0.14.0-beta3"
+    "react": "0.13.x || ^0.14.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 0",


### PR DESCRIPTION
Current version of react 0.14 is 0.14.0-rc1. But react-mdl depends on beta3 yet. This patch fixes this.