### PR TITLE
Use defaultProps instead of falling back in render

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -12,12 +12,13 @@ class Button extends React.Component {
         ripple: PropTypes.bool
     }
 
+    static defaultProps = {
+        ripple: true
+    }
+
     render() {
         var { accent, className, colored,
             primary, raised, ripple, ...otherProps } = this.props;
-
-        // enable ripple by default
-        ripple = ripple !== false;
 
         var buttonClasses = classNames('mdl-button mdl-js-button', {
             'mdl-js-ripple-effect': ripple,

--- a/src/IconToggle.js
+++ b/src/IconToggle.js
@@ -14,6 +14,10 @@ class IconToggle extends React.Component {
         ripple: PropTypes.bool
     }
 
+    static defaultProps = {
+        ripple: true
+    }
+
     _handleChange = (event) => {
         this.props.onChange(event.target.checked);
     }
@@ -21,9 +25,6 @@ class IconToggle extends React.Component {
     render() {
         var { className, checked, disabled, id, name, ripple, ...otherProps } = this.props;
         var inputId = 'icon-toggle-' + id;
-
-        // enable ripple by default
-        ripple = ripple !== false;
 
         var classes = classNames('mdl-icon-toggle mdl-js-icon-toggle', {
             'mdl-js-ripple-effect': ripple

--- a/src/Menu.js
+++ b/src/Menu.js
@@ -12,13 +12,14 @@ class Menu extends React.Component {
         valign: PropTypes.oneOf(['bottom', 'top'])
     }
 
+    static defaultProps = {
+        align: 'left',
+        valign: 'bottom',
+        ripple: true
+    }
+
     render() {
         var { align, className, ripple, target, valign, ...otherProps} = this.props;
-
-        align = align || 'left';
-        valign = valign || 'bottom';
-        // enable ripple by default
-        ripple = ripple !== false;
 
         var classes = classNames('mdl-menu mdl-js-menu', {
             [`mdl-menu--${valign}-${align}`]: true,

--- a/src/Radio.js
+++ b/src/Radio.js
@@ -16,6 +16,10 @@ class Radio extends React.Component {
         ]).isRequired
     }
 
+    static defaultProps = {
+        ripple: true
+    }
+
     _handleChange = (event) => {
         this.props.onChange(event.target.value);
     }
@@ -23,9 +27,6 @@ class Radio extends React.Component {
     render() {
         var { checked, className, disabled, name, ripple, value } = this.props;
         var inputId = 'radio-' + name.replace(/\s+/g, '') + '-' + value.replace(/\s+/g, '');
-
-        // enable ripple by default
-        ripple = ripple !== false;
 
         var classes = classNames('mdl-radio mdl-js-radio', {
             'mdl-js-ripple-effect': ripple

--- a/src/Switch.js
+++ b/src/Switch.js
@@ -12,6 +12,10 @@ class Switch extends React.Component {
         ripple: PropTypes.bool
     }
 
+    static defaultProps = {
+        ripple: true
+    }
+
     _handleChange = (event) => {
         this.props.onChange(event.target.checked);
     }
@@ -19,9 +23,6 @@ class Switch extends React.Component {
     render() {
         var { checked, className, disabled, id, ripple } = this.props;
         var inputId = 'switch-' + id;
-
-        // enable ripple by default
-        ripple = ripple !== false;
 
         var classes = classNames('mdl-switch mdl-js-switch', {
             'mdl-js-ripple-effect': ripple

--- a/src/footer/Footer.js
+++ b/src/footer/Footer.js
@@ -8,10 +8,12 @@ class Footer extends React.Component {
         size: PropTypes.oneOf(['mini', 'mega'])
     }
 
+    static defaultProps = {
+        size: 'mega'
+    }
+
     render() {
         var { className, size, ...otherProps } = this.props;
-
-        size = size || 'mega';
 
         var classes = classNames({
             [`mdl-${size}-footer`]: true

--- a/src/footer/Section.js
+++ b/src/footer/Section.js
@@ -10,10 +10,12 @@ class Section extends React.Component {
         type: PropTypes.oneOf(['top', 'middle', 'bottom', 'left', 'right'])
     }
 
+    static defaultProps = {
+        type: 'mega'
+    }
+
     render() {
         var { className, logo, size, type, ...otherProps } = this.props;
-
-        type = type || 'mega';
 
         var classes = classNames({
             [`mdl-${size}-footer__${type}-section`]: true

--- a/src/tabs/Tab.js
+++ b/src/tabs/Tab.js
@@ -10,6 +10,10 @@ class Tab extends React.Component {
         tabId: PropTypes.number
     }
 
+    static defaultProps = {
+        style: {}
+    }
+
     _handleClick = () => {
         this.props.onTabClick(this.props.tabId);
     }
@@ -21,7 +25,6 @@ class Tab extends React.Component {
             'is-active': active
         }, className);
 
-        style = style || {};
         style.cursor = 'pointer';
 
         return <a className={classes} onClick={this._handleClick} style={style} {...otherProps}>{this.props.children}</a>;

--- a/src/tabs/Tabs.js
+++ b/src/tabs/Tabs.js
@@ -15,6 +15,10 @@ class Tabs extends React.Component {
         onChange: PropTypes.func.isRequired
     }
 
+    static defaultProps = {
+        activeTab: 0
+    }
+
     _handleClickTab = (tabId) => {
         this.props.onChange(tabId);
     }
@@ -30,7 +34,7 @@ class Tabs extends React.Component {
                     {React.Children.map(this.props.children, (child, index) => {
                         return React.cloneElement(child, {
                             tabId: index,
-                            active: index === (activeTab || 0),
+                            active: index === activeTab,
                             onTabClick: this._handleClickTab
                         });
                     })}


### PR DESCRIPTION
I think it's more clear to use `defaultProps` instead of falling back in render, because you understand default values better looking at the top of component code.