### PR TITLE
Better way to upgrade/downgrade mdl components

### DIFF
--- a/src/ProgressBar.js
+++ b/src/ProgressBar.js
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
+import mdlUpgrade from './utils/mdlUpgrade';
 
 class ProgressBar extends React.Component {
     static propTypes = {
@@ -10,8 +11,6 @@ class ProgressBar extends React.Component {
     }
 
     componentDidMount(){
-        // Can't use the mdlUpgrade component because we need access to the Material internal object
-        componentHandler.upgradeElement(React.findDOMNode(this));
         this.setProgress(this.props.progress);
         this.setBuffer(this.props.buffer);
     }
@@ -19,10 +18,6 @@ class ProgressBar extends React.Component {
     componentDidUpdate() {
         this.setProgress(this.props.progress);
         this.setBuffer(this.props.buffer);
-    }
-
-    componentWillUnmount(){
-        componentHandler.downgradeElements(React.findDOMNode(this));
     }
 
     setProgress(progress) {
@@ -48,4 +43,4 @@ class ProgressBar extends React.Component {
     }
 }
 
-export default ProgressBar;
+export default mdlUpgrade(ProgressBar);

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -1,8 +1,8 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
-import mdlUpgrade from './utils/mdlUpgrade';
+import MDLComponent from './utils/MDLComponent';
 
-class Tooltip extends React.Component {
+export default class Tooltip extends React.Component {
     static propTypes = {
         children: PropTypes.oneOfType([
             PropTypes.element,
@@ -33,16 +33,16 @@ class Tooltip extends React.Component {
 
         return (
             <div style={{display: 'inline-block'}} {...otherProps}>
-                {React.cloneElement(element, {
-                    id: id
-                })}
-                {React.cloneElement(label, {
-                    htmlFor: id,
-                    className: classNames('mdl-tooltip', { 'mdl-tooltip--large': large })
-                })}
+                {React.cloneElement(element, { id })}
+                <MDLComponent>
+                    {React.cloneElement(label, {
+                        htmlFor: id,
+                        className: classNames('mdl-tooltip', {
+                            'mdl-tooltip--large': large
+                        })
+                    })}
+                </MDLComponent>
             </div>
         );
     }
 }
-
-export default mdlUpgrade(Tooltip);

--- a/src/utils/MDLComponent.js
+++ b/src/utils/MDLComponent.js
@@ -1,0 +1,15 @@
+import { Children, Component, findDOMNode } from 'react';
+
+export default class MDLComponent extends Component {
+    componentDidMount() {
+        componentHandler.upgradeElement(findDOMNode(this));
+    }
+
+    componentWillUnmount() {
+        componentHandler.downgradeElements(findDOMNode(this));
+    }
+
+    render() {
+        return Children.only(this.props.children);
+    }
+}

--- a/src/utils/mdlUpgrade.js
+++ b/src/utils/mdlUpgrade.js
@@ -1,19 +1,12 @@
 import React from 'react';
+import MDLComponent from './MDLComponent';
 
-export default (Component) => {
-    class MDLUpgradedComponent extends React.Component {
-        componentDidMount() {
-            componentHandler.upgradeElement(React.findDOMNode(this));
-        }
+export default Component => {
+    const render = Component.prototype.render;
 
-        componentWillUnmount() {
-            componentHandler.downgradeElements(React.findDOMNode(this));
-        }
+    Component.prototype.render = function() {
+        return <MDLComponent>{this::render()}</MDLComponent>;
+    };
 
-        render() {
-            return <Component {...this.props} />;
-        }
-    }
-
-    return MDLUpgradedComponent;
+    return Component;
 };


### PR DESCRIPTION
Here I'm adding ref `mdlComponent` to components which render wrappers around mdl components (actually it's just Tooltip).

Another change here is wrapping methods instead of wrapping whole components. Aside from easier access to `this.refs` it now looks better in `react-devtools`.