### PR TITLE
Force `error`props display if `pattern` isn't set

### DIFF
--- a/demo/textfield/textfield.js
+++ b/demo/textfield/textfield.js
@@ -18,8 +18,14 @@ class Demo extends React.Component {
             textfield3: '',
             textfield4: '',
             textfield5: '',
-            textfield6: ''
+            textfield6: '',
+            textfield7a: '',
+            textfield7b: ''
         };
+    }
+
+    checkPasswordConfirmation() {
+        return this.state.textfield7b != this.state.textfield7a ? 'Passwords don\'t match!' : null;
     }
 
     render() {
@@ -78,6 +84,22 @@ class Demo extends React.Component {
                     label="Expandable Input"
                     expandable={true}
                     expandableIcon="search"
+                />
+
+                {/* Note: this is a naive implementation of checking passwords, solely for demo purpose.
+                  * A more robust implementation would maybe store the error check result in the state 
+                  * and share it with both textfields */}
+                <p>Password confirmation textfields</p>
+                <Textfield
+                    value={this.state.textfield7a}
+                    onChange={linkToState(this, 'textfield7a')}
+                    label="Enter password"
+                />
+                <Textfield
+                    value={this.state.textfield7b}
+                    onChange={linkToState(this, 'textfield7b')}
+                    label="Enter password again"
+                    error={this.checkPasswordConfirmation()}
                 />
 
 

--- a/src/Textfield.js
+++ b/src/Textfield.js
@@ -36,7 +36,7 @@ class Textfield extends React.Component {
         }
         if(this.props.error && !this.props.pattern) {
             // At every re-render, mdl will set 'is-invalid' class according to the 'pattern' props validity
-            // If we want to for the error display, we have to override mdl 'is-invalid' value.
+            // If we want to force the error display, we have to override mdl 'is-invalid' value.
             React.findDOMNode(this).className = 
                 classNames(React.findDOMNode(this).className, {'is-invalid': true});
         }

--- a/src/Textfield.js
+++ b/src/Textfield.js
@@ -34,6 +34,12 @@ class Textfield extends React.Component {
         if(this.props.disabled !== prevProps.disabled) {
             React.findDOMNode(this).MaterialTextfield.checkDisabled();
         }
+        if(this.props.error && !this.props.pattern) {
+            // At every re-render, mdl will set 'is-invalid' class according to the 'pattern' props validity
+            // If we want to for the error display, we have to override mdl 'is-invalid' value.
+            React.findDOMNode(this).className = 
+                classNames(React.findDOMNode(this).className, {'is-invalid': true});
+        }
     }
 
     _handleChange = (e) => {


### PR DESCRIPTION
Fixes #37 and #42 