### PR TITLE
Fixed peer dependencies so package can be installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     "webpack-dev-server": "^1.12.0"
   },
   "peerDependencies": {
-    "react": "0.14.x",
-    "react-dom": "0.14.x"
+    "react": "^0.14.0",
+    "react-dom": "^0.14.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 0",


### PR DESCRIPTION
Not able to install with the current package.json settings:

```
npm WARN peerDependencies The peer dependency react-dom@0.14.x included from react-mdl will no
npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency 
npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
npm ERR! Darwin 15.0.0
npm ERR! argv "/usr/local/Cellar/node/4.1.1/bin/node" "/usr/local/bin/npm" "install" "react-mdl" "--save"
npm ERR! node v4.1.1
npm ERR! npm  v2.14.4
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package react-dom@0.14.0-rc1 does not satisfy its siblings' peerDependencies requirements!
```