### PR TITLE
Render Badge if undefined or null

### DIFF
--- a/demo/badge/badge.js
+++ b/demo/badge/badge.js
@@ -20,6 +20,8 @@ class Demo extends React.Component {
                 <Badge text={4}>Inbox</Badge>
                 <p>Icon badge</p>
                 <Badge text="♥">Mood</Badge>
+                <p>Badge text is undefined</p>
+                <Badge>Mood</Badge>
             </div>
         );
     }

--- a/src/Badge.js
+++ b/src/Badge.js
@@ -6,9 +6,6 @@ var Badge = (props) => {
     // No badge if no children
     if(!React.Children.count(children)) return null;
 
-    // No text -> No need of badge
-    if(text === null || typeof text === 'undefined') return children;
-
     var element;
     if(typeof children === 'string') {
         element = <span>{children}</span>;

--- a/test/Badge.test.js
+++ b/test/Badge.test.js
@@ -47,38 +47,20 @@ describe('Badge', function() {
         assert.equal(output.props.children, 'Inbox');
     });
 
-    describe('does not render badge when', function() {
-        it('no children', function() {
-            shallowRenderer.render(<Badge text="4" />);
-            var output = shallowRenderer.getRenderOutput();
+    it('does not render badge when there are no children', function() {
+        shallowRenderer.render(<Badge text="4" />);
+        var output = shallowRenderer.getRenderOutput();
 
-            assert.equal(null, output);
-        });
+        assert.equal(null, output);
+    });
 
-        it('badge text is on text child', function() {
-            shallowRenderer.render(<Badge text={null}>Inbox</Badge>);
-            var output = shallowRenderer.getRenderOutput();
+    it('renders if text is undefined', function() {
+        shallowRenderer.render(<Badge>Text</Badge>);
+        var output = shallowRenderer.getRenderOutput();
 
-            assert.equal('Inbox', output);
-        });
-
-        it('badge text is null on complex child', function() {
-            shallowRenderer.render(<Badge text={null}><Icon name="account_box" /></Badge>);
-            var output = shallowRenderer.getRenderOutput();
-
-            assert.equal(Icon, output.type);
-            assert.notEqual('mdl-badge', output.props.className);
-            assert.equal(undefined, output.props['data-badge']);
-        });
-
-        it('it does not have any text', function() {
-            shallowRenderer.render(<Badge><Icon name="account_box" /></Badge>);
-            var output = shallowRenderer.getRenderOutput();
-
-            assert.equal(Icon, output.type);
-            assert.notEqual('mdl-badge', output.props.className);
-            assert.equal(undefined, output.props['data-badge']);
-        });
+        assert.equal('mdl-badge', output.props.className);
+        assert.equal('Text', output.props.children);
+        assert.equal(undefined, output.props['data-badge']);
     });
 
 });


### PR DESCRIPTION
See #81 

That's how it supposed to work.
There's no need to check `text` prop at all, it just renders in resulting DOM or not and that's it :-)

Also previously it would throw if we pass `string` as a `children`.