### PR TITLE
Fix: change value to defaultValue

### DIFF
--- a/docs/pages/textfield.md
+++ b/docs/pages/textfield.md
@@ -74,4 +74,4 @@
 | required | Boolean | Set the textfield as required | Optional |
 | rows | Number | Defines the number of rows (multiline) | Optional |
 | style | Object | Defines the custom styles for the container | Optional |
-| value | String or Number | Definest the 'current' value | Optional |
+| defaultValue | String or Number | Defines the 'current' value | Optional |


### PR DESCRIPTION
if `value` is set, it cannot be modified (visually at least). `defaultValue` seems to have the expected behavior.