### PR TITLE
Changes layout component accepted PropTypes.

### DIFF
--- a/src/Footer/DropDownSection.js
+++ b/src/Footer/DropDownSection.js
@@ -21,7 +21,7 @@ const DropDownSection = (props) => {
 DropDownSection.propTypes = {
     className: PropTypes.string,
     size: PropTypes.oneOf(['mini', 'mega']),
-    title: PropTypes.string.isRequired
+    title: PropTypes.node.isRequired
 };
 DropDownSection.defaultProps = {
     size: 'mega'

--- a/src/Footer/Section.js
+++ b/src/Footer/Section.js
@@ -19,7 +19,7 @@ const Section = (props) => {
 
 Section.propTypes = {
     className: PropTypes.string,
-    logo: PropTypes.string,
+    logo: PropTypes.node,
     size: PropTypes.oneOf(['mini', 'mega']),
     type: PropTypes.oneOf(['top', 'middle', 'bottom', 'left', 'right'])
 };

--- a/src/Layout/Drawer.js
+++ b/src/Layout/Drawer.js
@@ -15,7 +15,7 @@ const Drawer = props => {
 };
 Drawer.propTypes = {
     className: PropTypes.string,
-    title: PropTypes.string
+    title: PropTypes.node
 };
 
 export default Drawer;

--- a/src/Layout/Header.js
+++ b/src/Layout/Header.js
@@ -33,7 +33,7 @@ Header.propTypes = {
     className: PropTypes.string,
     scroll: PropTypes.bool,
     seamed: PropTypes.bool,
-    title: PropTypes.any,
+    title: PropTypes.node,
     transparent: PropTypes.bool,
     waterfall: PropTypes.bool
 };

--- a/src/Layout/HeaderRow.js
+++ b/src/Layout/HeaderRow.js
@@ -17,7 +17,7 @@ const HeaderRow = props => {
 };
 HeaderRow.propTypes = {
     className: PropTypes.string,
-    title: PropTypes.any
+    title: PropTypes.node
 };
 
 export default HeaderRow;


### PR DESCRIPTION
`PropTypes.node` accepts anything that can be rendered: numbers, strings, elements or an array containing these types.

Title and logo props are only used as react nodes so this should be perfect.

Imo this is pretty trivial change, but if you want I can add regression tests.