### PR TITLE
Do not reset the is-invalid class unless Textfield's underlying state has changed.

### DIFF
--- a/src/Textfield.js
+++ b/src/Textfield.js
@@ -38,7 +38,7 @@ class Textfield extends React.Component {
         if(this.props.value !== prevProps.value && this.refs.input !== document.activeElement) {
             findDOMNode(this).MaterialTextfield.change(this.props.value);
         }
-        if(this.props.error && !this.props.pattern) {
+        if(this.props.error && !this.props.pattern && prevProps.error !== this.props.error) {
             // At every re-render, mdl will set 'is-invalid' class according to the 'pattern' props validity
             // If we want to force the error display, we have to override mdl 'is-invalid' value.
             const elt = findDOMNode(this);


### PR DESCRIPTION
This is to prevent the is-invalid class from getting reset on the element after MDL's javascript has cleared it due to user interaction.

For example:
- Suppose we submit the form and the error attribute gets set. 
- We then fix our erroneous form input and from our typing in the textfield, MDL will automatically clear the is-invalid class off of the Textfield. 
- If we hit submit again, the submit will trigger componentDidUpdate which will set the class 'is-invalid' back on to the Textfield. 
- When our backend ajax request comes back and clears the error attribute on our Textfield component, componentDidUpdate will run again but the is-invalid class will not get removed.

Thus, the Textfield will show up in red despite having no error.