### PR TITLE
Fix src path in DocApp

### DIFF
--- a/docs/src/DocApp.js
+++ b/docs/src/DocApp.js
@@ -4,7 +4,7 @@ import Pages from '../pages/html';
 import {
     Layout, Header, Drawer, Content, Navigation,
     Icon, Grid, Cell
-} from '../../';
+} from '../../src/';
 
 class DocApp extends React.Component {
     render() {


### PR DESCRIPTION
When running `npm serve-docs`, this error is present:

```
ERROR in ./docs/src/DocApp.js
Module not found: Error: Cannot resolve directory '../..' in /home/vagrant/react-mdl/docs/src
 @ ./docs/src/DocApp.js 19:8-25
```