### PR TITLE
Fix src path in docs/app

### DIFF
--- a/docs/src/app.js
+++ b/docs/src/app.js
@@ -8,7 +8,7 @@ import Pages from '../pages/html';
 import pageComponentHelper from './PageComponentHelper';
 
 // export all ReactMDL into global so we can generate demos
-import * as ReactMDL from '../../';
+import * as ReactMDL from '../../src/';
 for(const component in ReactMDL) {
     if(ReactMDL.hasOwnProperty(component)) {
         global[component] = ReactMDL[component];


### PR DESCRIPTION
When running `npm serve docs`, this error is present:

```
ERROR in ./docs/src/app.js
Module not found: Error: Cannot resolve directory '../..' in /home/vagrant/react-mdl/docs/src
 @ ./docs/src/app.js 25:8-25
```