### PR TITLE
Allow Textfield error to be of node type

### DIFF
--- a/src/Textfield.js
+++ b/src/Textfield.js
@@ -7,7 +7,7 @@ class Textfield extends React.Component {
     static propTypes = {
         className: PropTypes.string,
         disabled: PropTypes.bool,
-        error: PropTypes.string,
+        error: PropTypes.node,
         expandable: PropTypes.bool,
         expandableIcon: PropTypes.string,
         floatingLabel: PropTypes.bool,


### PR DESCRIPTION
In case you want to display a link in the error message.