### PR TITLE
Add Dialog components

### DIFF
--- a/docs/pages/dialogs.md
+++ b/docs/pages/dialogs.md
@@ -1,0 +1,95 @@
+# Dialogs
+
+This component uses [dialog element](https://www.w3.org/TR/2013/CR-html5-20130806/interactive-elements.html#the-dialog-element), which is only supported by Chrome and Opera currently. For other browsers, you need to include a [polyfill](https://github.com/GoogleChrome/dialog-polyfill) in your code.
+
+## Demo
+
+### Simple Dialog
+
+```jsx_demo_class
+class Demo extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  openDialog() {
+    this.setState({
+      openDialog: true
+    });
+  }
+
+  closeDialog() {
+    this.setState({
+      openDialog: false
+    });
+  }
+
+  render() {
+    return (
+      <div>
+        <Button colored onClick={this.openDialog.bind(this)} raised ripple>Show Dialog</Button>
+        <Dialog open={this.state.openDialog}>
+          <DialogTitle>Allow data collection?</DialogTitle>
+          <DialogContent>
+            <p>Allowing us to collect data will let us get you the information you want faster.</p>
+          </DialogContent>
+          <DialogActions>
+            <Button type='button'>Agree</Button>
+            <Button type='button' onClick={this.closeDialog.bind(this)}>Disagree</Button>
+          </DialogActions>
+        </Dialog>
+      </div>
+    );
+  }
+}
+```
+
+### Dialog with Full Width Actions
+
+```jsx_demo_class
+class Demo extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  openDialog() {
+    this.setState({
+      openDialog: true
+    });
+  }
+
+  closeDialog() {
+    this.setState({
+      openDialog: false
+    });
+  }
+
+  render() {
+    return (
+      <div>
+        <Button colored onClick={this.openDialog.bind(this)} raised ripple>Show Modal</Button>
+        <Dialog open={this.state.openDialog}>
+          <DialogTitle>Allow this site to collect usage data to improve your experience?</DialogTitle>
+          <DialogContent>
+            <p>Allowing us to collect data will let us get you the information you want faster.</p>
+          </DialogContent>
+          <DialogActions fullWidth>
+            <Button type='button'>Agree</Button>
+            <Button type='button' onClick={this.closeDialog.bind(this)}>Disagree</Button>
+          </DialogActions>
+        </Dialog>
+      </div>
+    );
+  }
+}
+```
+
+## Configuration
+
+| Element   | Prop         | Type      | Effect       | Remarks      |
+|:----------|:-------------|:----------|:-------------|:-------------|
+| Dialog    | open         | Boolean   | Set the open state of the dialog  | Optional |
+| DialogTitle | component  | String, Element, Function | Specify the custom component to use to render the element | Optional. Default 'h4' |
+| DialogActions | fullWidth | Boolean  | Apply the full-width effect to all children of dialog actions  | Optional |

--- a/src/Dialog/Dialog.js
+++ b/src/Dialog/Dialog.js
@@ -1,0 +1,41 @@
+import React, { PropTypes } from 'react';
+import { findDOMNode } from 'react-dom';
+import classNames from 'classnames';
+
+class Dialog extends React.Component {
+    static propTypes = {
+        className: PropTypes.string,
+        open: PropTypes.bool
+    };
+
+    componentDidMount() {
+        if(this.props.open) {
+            findDOMNode(this).showModal();
+        }
+    }
+
+    componentDidUpdate(prevProps) {
+        if(this.props.open !== prevProps.open) {
+            if(this.props.open) {
+                findDOMNode(this).showModal();
+            }
+            else {
+                findDOMNode(this).close();
+            }
+        }
+    }
+
+    render() {
+        const { className, children, open, ...otherProps } = this.props;
+
+        const classes = classNames('mdl-dialog', className);
+
+        return (
+            <dialog className={classes} {...otherProps}>
+                {children}
+            </dialog>
+        );
+    }
+}
+
+export default Dialog;

--- a/src/Dialog/DialogActions.js
+++ b/src/Dialog/DialogActions.js
@@ -1,0 +1,23 @@
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+
+const DialogActions = (props) => {
+    const { className, fullWidth, children, ...otherProps } = props;
+
+    const classes = classNames('mdl-dialog__actions', {
+        'mdl-dialog__actions--full-width': fullWidth
+    }, className);
+
+    return (
+        <div className={classes} {...otherProps}>
+            {children}
+        </div>
+    );
+};
+
+DialogActions.propTypes = {
+    className: PropTypes.string,
+    fullWidth: PropTypes.bool
+};
+
+export default DialogActions;

--- a/src/Dialog/DialogTitle.js
+++ b/src/Dialog/DialogTitle.js
@@ -1,0 +1,24 @@
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+
+const DialogTitle = (props) => {
+    const { className, component, children, ...otherProps } = props;
+
+    const classes = classNames('mdl-dialog__title', className);
+
+    return React.createElement(component || 'h4', {
+        className: classes,
+        ...otherProps
+    }, children);
+};
+
+DialogTitle.propTypes = {
+    className: PropTypes.string,
+    component: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.element,
+        PropTypes.func
+    ])
+};
+
+export default DialogTitle;

--- a/src/Dialog/__tests__/Dialog-test.js
+++ b/src/Dialog/__tests__/Dialog-test.js
@@ -1,0 +1,95 @@
+/* eslint-env mocha */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { render, renderDOM } from '../../__tests__/render';
+import { Dialog } from '../';
+
+describe('Dialog', () => {
+    it('should render a dialog with the mdl-dialog css class', () => {
+        const output = render(<Dialog />);
+
+        expect(output.type).toBe('dialog');
+        expect(output.props.className).toInclude('mdl-dialog');
+    });
+
+    it('should allow custom css classes', () => {
+        const output = render(<Dialog className="my-dialog" />);
+
+        expect(output.props.className)
+            .toInclude('mdl-dialog')
+            .toInclude('my-dialog');
+    });
+
+    it('should not open by default', () => {
+        const spy = {
+            showModal: expect.createSpy()
+        };
+        expect.spyOn(ReactDOM, 'findDOMNode').andReturn(spy);
+        renderDOM(<Dialog />);
+
+        expect(spy.showModal).toNotHaveBeenCalled();
+        expect.restoreSpies();
+    });
+
+    it('should open when specified on initial render', () => {
+        const spy = {
+            showModal: expect.createSpy()
+        };
+        expect.spyOn(ReactDOM, 'findDOMNode').andReturn(spy);
+        renderDOM(<Dialog open />);
+
+        expect(spy.showModal).toHaveBeenCalled();
+        expect.restoreSpies();
+    });
+
+    it('should open when open props is changed from false to true', () => {
+        const el = renderDOM(<Dialog />);
+        const spy = expect.spyOn(el, 'showModal');
+
+        ReactDOM.render(<Dialog open />, el.parentNode);
+        expect(spy).toHaveBeenCalled();
+        expect.restoreSpies();
+    });
+
+    it('should not open when open props is unchanged from its previous false value', () => {
+        const el = renderDOM(<Dialog />);
+        const spy = expect.spyOn(el, 'showModal');
+
+        ReactDOM.render(<Dialog />, el.parentNode);
+        expect(spy).toNotHaveBeenCalled();
+        expect.restoreSpies();
+    });
+
+    it('should close when open props is changed from true to false', () => {
+        expect.spyOn(Dialog.prototype, 'componentDidMount');
+        const el = renderDOM(<Dialog open />);
+        const spy = expect.spyOn(el, 'close');
+
+        ReactDOM.render(<Dialog />, el.parentNode);
+        expect(spy).toHaveBeenCalled();
+        expect.restoreSpies();
+    });
+
+    it('should not close when open props is unchanged from its previous true value', () => {
+        expect.spyOn(Dialog.prototype, 'componentDidMount');
+        const el = renderDOM(<Dialog open />);
+        const spy = expect.spyOn(el, 'close');
+
+        ReactDOM.render(<Dialog open />, el.parentNode);
+        expect(spy).toNotHaveBeenCalled();
+        expect.restoreSpies();
+    });
+
+    it('should render with the children', () => {
+        const element = (
+            <Dialog>
+                <div>Inner Dialog</div>
+            </Dialog>
+        );
+        const output = render(element);
+
+        expect(output.props.children)
+            .toEqual(<div>Inner Dialog</div>);
+    });
+});

--- a/src/Dialog/__tests__/DialogActions-test.js
+++ b/src/Dialog/__tests__/DialogActions-test.js
@@ -1,0 +1,50 @@
+/* eslint-env mocha */
+import expect from 'expect';
+import React from 'react';
+import { render } from '../../__tests__/render';
+import { DialogActions } from '../';
+
+describe('Dialog', () => {
+    describe('DialogActions', () => {
+        it('should render a div with the actions css class', () => {
+            const output = render(<DialogActions />);
+
+            expect(output.type).toBe('div');
+            expect(output.props.className).toInclude('mdl-dialog__actions');
+        });
+
+        it('should allow custom css classes', () => {
+            const output = render(<DialogActions className="my-dialog-actions" />);
+
+            expect(output.props.className)
+                .toInclude('mdl-dialog__actions')
+                .toInclude('my-dialog-actions');
+        });
+
+        it('shoud not be full-width by default', () => {
+            const output = render(<DialogActions />);
+
+            expect(output.props.className)
+                .toExclude('mdl-dialog__actions--full-width');
+        });
+
+        it('shoud be full-width when specified', () => {
+            const output = render(<DialogActions fullWidth />);
+
+            expect(output.props.className)
+                .toInclude('mdl-dialog__actions--full-width');
+        });
+
+        it('should render with the children', () => {
+            const element = (
+                <DialogActions>
+                    <div>Inner Dialog Actions</div>
+                </DialogActions>
+            );
+            const output = render(element);
+
+            expect(output.props.children)
+                .toEqual(<div>Inner Dialog Actions</div>);
+        });
+    });
+});

--- a/src/Dialog/__tests__/DialogTitle-test.js
+++ b/src/Dialog/__tests__/DialogTitle-test.js
@@ -1,0 +1,43 @@
+/* eslint-env mocha */
+import expect from 'expect';
+import React from 'react';
+import { render } from '../../__tests__/render';
+import { DialogTitle } from '../';
+
+describe('Dialog', () => {
+    describe('DialogTitle', () => {
+        it('should render an h4 with the title css class by default', () => {
+            const output = render(<DialogTitle />);
+
+            expect(output.type).toBe('h4');
+            expect(output.props.className).toInclude('mdl-dialog__title');
+        });
+
+        it('should allow custom component', () => {
+            const output = render(<DialogTitle component="div" />);
+
+            expect(output.type).toBe('div');
+            expect(output.props.className).toInclude('mdl-dialog__title');
+        });
+
+        it('should allow custom css classes', () => {
+            const output = render(<DialogTitle className="my-dialog-title" />);
+
+            expect(output.props.className)
+                .toInclude('mdl-dialog__title')
+                .toInclude('my-dialog-title');
+        });
+
+        it('should render with the children', () => {
+            const element = (
+                <DialogTitle>
+                    <span>Untitled</span>
+                </DialogTitle>
+            );
+            const output = render(element);
+
+            expect(output.props.children)
+                .toEqual(<span>Untitled</span>);
+        });
+    });
+});

--- a/src/Dialog/index.js
+++ b/src/Dialog/index.js
@@ -1,0 +1,6 @@
+import basicClassCreator from '../utils/basicClassCreator';
+
+export Dialog from './Dialog';
+export DialogTitle from './DialogTitle';
+export const DialogContent = basicClassCreator('DialogContent', 'mdl-dialog__content');
+export DialogActions from './DialogActions';

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,10 @@ export {
 } from './Card';
 export Checkbox from './Checkbox';
 export DataTable from './DataTable';
+export {
+    Dialog, DialogTitle, DialogContent,
+    DialogActions
+} from './Dialog';
 export FABButton from './FABButton';
 export {
     Footer, FooterSection, FooterDropDownSection,


### PR DESCRIPTION
Closes #200, It works with `material.js` and `material.css` in latest mdl release and the one you updated 2 hours ago (as of this comment).

Also, I have no idea how to make showDialog native method runs while testing reactDOM (I got an error with few documentations), so I have to leverage on spying the method calls themselves, if you don't mind.

Thanks!
