### PR TITLE
adds Snackbar component

### DIFF
--- a/docs/pages/snackbar.md
+++ b/docs/pages/snackbar.md
@@ -1,0 +1,87 @@
+# Snackbar
+
+## Demo
+
+```jsx_demo_class
+{/* Example of a snackbar */}
+class Demo extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleShowSnackbar = this.handleShowSnackbar.bind(this);
+    this.handleTimeoutSnackbar = this.handleTimeoutSnackbar.bind(this);
+    this.handleClickActionSnackbar = this.handleClickActionSnackbar.bind(this);
+    this.state = { isSnackbarActive: false };
+  }
+
+  handleShowSnackbar() {
+    this.setState({
+      isSnackbarActive: true,
+      btnBgColor: '#' +
+        Math.floor(Math.random() * 0xFFFFFF).toString(16)
+    });
+  }
+  handleTimeoutSnackbar() {
+    this.setState({ isSnackbarActive: false });
+  }
+  handleClickActionSnackbar() {
+    this.setState({
+      btnBgColor: ''
+    });
+  }
+  render() {
+    const { btnBgColor, isSnackbarActive } = this.state;
+    return (
+      <div>
+        <Button raised style={{backgroundColor: btnBgColor}} onClick={this.handleShowSnackbar}>Show a Snackbar</Button>
+        <Snackbar
+          active={isSnackbarActive}
+          onClick={this.handleClickActionSnackbar}
+          onTimeout={this.handleTimeoutSnackbar}
+          action="Undo">Button color changed.</Snackbar>
+      </div>
+    );
+  }
+}
+```
+
+```jsx_demo_class
+{/* Example of a toast (snackbar without action button) */}
+class Demo extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleShowSnackbar = this.handleShowSnackbar.bind(this);
+    this.handleTimeoutSnackbar = this.handleTimeoutSnackbar.bind(this);
+    this.state = { isSnackbarActive: false };
+  }
+
+  handleShowSnackbar() {
+    this.setState({ isSnackbarActive: true });
+  }
+  handleTimeoutSnackbar() {
+    this.setState({ isSnackbarActive: false });
+  }
+  render() {
+    const { isSnackbarActive } = this.state;
+    return (
+      <div>
+        <Button raised onClick={this.handleShowSnackbar}>Show a Toast</Button>
+        <Snackbar
+          active={isSnackbarActive}
+          onTimeout={this.handleTimeoutSnackbar}>
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce varius luctus quam. Fusce quis blandit libero. Donec accumsan nunc lectus, vel blandit diam bibendum ac. Integer faucibus, lorem et convallis fermentum, diam dolor imperdiet mi, nec iaculis risus mauris id elit. Vivamus vel eros dapibus, molestie ante ut, vestibulum sem.
+          </Snackbar>
+      </div>
+    );
+  }
+}
+```
+
+## Configuration
+
+| Prop         | Type      | Effect       | Remarks      |
+|:-------------|:----------|:-------------|:-------------|
+| action       | String    | Specify the label of the action button  | Optional |
+| active       | Boolean   | Set the snackbar visible | Required. Should be false when mounting the component |
+| onActionClick| Function  | Function to call when the action button is clicked  | Optional |
+| onTimeout    | Function  | Function to call when the snackbar is getting hidden  | Required |
+| timeout      | Number    | Defines the time (in ms) to show the snackbar | Optional. Default 2750 |

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
   "scripts": {
     "test": "karma start --single-run",
     "posttest": "npm run lint",
+    "test:watch": "karma start --auto-watch",
     "lint": "eslint docs src scripts",
     "compile": "rm -rf lib && babel src --ignore __tests__ --out-dir lib",
     "serve-docs": "npm run build-docs && webpack-dev-server --content-base out/docs/",

--- a/src/Snackbar.js
+++ b/src/Snackbar.js
@@ -1,0 +1,78 @@
+import React, { PropTypes } from 'react';
+import classNames from 'classnames';
+
+// This component doesn't use the javascript from MDL.
+// This is the expected behavior and the reason is because it's not written in
+// a way to make it easy to use with React.
+const ANIMATION_LENGTH = 250;
+
+class Snackbar extends React.Component {
+    static propTypes = {
+        action: PropTypes.string,
+        active: PropTypes.bool.isRequired,
+        className: PropTypes.string,
+        onActionClick: PropTypes.func,
+        onTimeout: PropTypes.func.isRequired,
+        timeout: PropTypes.number
+    };
+
+    static defaultProps = {
+        timeout: 2750
+    };
+
+    constructor(props) {
+        super(props);
+        this.clearTimer = this.clearTimer.bind(this);
+        this.timeoutId = null;
+        this.state = {
+            open: false
+        };
+    }
+
+    componentWillReceiveProps(nextProps) {
+        this.setState({
+            open: nextProps.active
+        });
+    }
+
+    componentDidUpdate() {
+        if(this.timeoutId) {
+            clearTimeout(this.timeoutId);
+        }
+
+        if(this.props.active) {
+            this.timeoutId = setTimeout(this.clearTimer, this.props.timeout);
+
+            // Hack fix to re-center the snackbar based on its content
+            this.refs.snackbar.style.marginLeft = `-${this.refs.snackbar.offsetWidth * 0.5}px`;
+        }
+    }
+
+    clearTimer() {
+        this.timeoutId = null;
+        this.setState({ open: false });
+
+        setTimeout(() => {
+            this.props.onTimeout();
+        }, ANIMATION_LENGTH);
+    }
+
+    render() {
+        const { action, active, className, children,
+            onActionClick, onTimeout, timeout, ...otherProps } = this.props;
+        const { open } = this.state;
+
+        const classes = classNames('mdl-snackbar', {
+            'mdl-snackbar--active': open
+        }, className);
+
+        return (
+            <div ref="snackbar" className={classes} aria-hidden={!open} {...otherProps}>
+                <div className="mdl-snackbar__text">{active && children}</div>
+                {active && action && <button className="mdl-snackbar__action" type="button" onClick={onActionClick}>{action}</button>}
+            </div>
+        );
+    }
+}
+
+export default Snackbar;

--- a/src/__tests__/Snackbar-test.js
+++ b/src/__tests__/Snackbar-test.js
@@ -1,0 +1,82 @@
+/* eslint-env mocha */
+import expect from 'expect';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Simulate } from 'react-addons-test-utils';
+import { render, renderDOM } from './render';
+import Snackbar from '../Snackbar';
+
+function noop() {}
+
+describe('Snackbar', () => {
+    it('should not be visible by default', () => {
+        const output = render(<Snackbar active={false} onTimeout={noop} />);
+
+        expect(output.type).toBe('div');
+        expect(output.props.className).toBe('mdl-snackbar');
+        expect(output.props['aria-hidden']).toBe(true);
+
+        const [text, action] = output.props.children;
+        expect(text.type).toBe('div');
+        expect(text.props.className).toBe('mdl-snackbar__text');
+        expect(text.props.children).toBe(false);
+
+        expect(action).toBe(false);
+    });
+
+    it('should allow custom css classes', () => {
+        const output = render(<Snackbar active={false} className="my-snackbar" onTimeout={noop} />);
+
+        expect(output.props.className).toInclude('my-snackbar');
+    });
+
+    it('should show the snackbar', (done) => {
+        const el = renderDOM(<Snackbar active={false} action="Undo" onTimeout={noop} />);
+        expect(el.className).toExclude('mdl-snackbar--active');
+        expect(el.getAttribute('aria-hidden')).toBe('true');
+        expect(el.querySelector('.mdl-snackbar__action')).toBe(null);
+
+        function hideSnackbar() {
+            ReactDOM.render(<Snackbar active={false} action="Undo" onTimeout={hideSnackbar} />, el.parentNode);
+            expect(el.className).toExclude('mdl-snackbar--active');
+            expect(el.getAttribute('aria-hidden')).toBe('true');
+            expect(el.querySelector('.mdl-snackbar__action')).toBe(null);
+            done();
+        }
+
+        ReactDOM.render(<Snackbar active action="Undo" timeout={200} onTimeout={hideSnackbar} />, el.parentNode);
+        expect(el.className).toInclude('mdl-snackbar--active');
+        expect(el.getAttribute('aria-hidden')).toBe('false');
+        expect(el.querySelector('.mdl-snackbar__action')).toNotBe(null);
+    });
+
+    it('should show the toast (snackbar without action)', (done) => {
+        const el = renderDOM(<Snackbar active={false} onTimeout={noop} />);
+        expect(el.className).toExclude('mdl-snackbar--active');
+        expect(el.getAttribute('aria-hidden')).toBe('true');
+        expect(el.querySelector('.mdl-snackbar__action')).toBe(null);
+
+        function hideToast() {
+            ReactDOM.render(<Snackbar active={false} onTimeout={hideToast} />, el.parentNode);
+            expect(el.className).toExclude('mdl-snackbar--active');
+            expect(el.getAttribute('aria-hidden')).toBe('true');
+            expect(el.querySelector('.mdl-snackbar__action')).toBe(null);
+            done();
+        }
+
+        ReactDOM.render(<Snackbar active timeout={200} onTimeout={hideToast} />, el.parentNode);
+        expect(el.className).toInclude('mdl-snackbar--active');
+        expect(el.getAttribute('aria-hidden')).toBe('false');
+        expect(el.querySelector('.mdl-snackbar__action')).toBe(null);
+    });
+
+    it('should click on the action button', (done) => {
+        function onActionClick() {
+            done();
+        }
+
+        const el = renderDOM(<Snackbar active action="Undo" onTimeout={noop} onActionClick={onActionClick} />);
+        expect(el.querySelector('.mdl-snackbar__action')).toNotBe(null);
+        Simulate.click(el.querySelector('.mdl-snackbar__action'));
+    });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,7 @@ export ProgressBar from './ProgressBar';
 export Radio from './Radio';
 export RadioGroup from './RadioGroup';
 export Slider from './Slider';
+export Snackbar from './Snackbar';
 export Spinner from './Spinner';
 export Switch from './Switch';
 export { Tabs, Tab, TabBar } from './Tabs';


### PR DESCRIPTION
Here's a first draft of a Snackbar (#199).

I decided to not use the JS implementation done by the MDL team since the implementation is not very React friendly.

Of course, the queue system available in the MDL implementation is not included, and will not be included.
In an application, it doesn't make sense to have multiple snackbar (they will overlap), so you should manually create a queue system to manage all type of notifications.

Here's the example with the button color change: http://codepen.io/anon/pen/GoYzLV?editors=0010