### PR TITLE
Removes key prop on inner components of Textfield

### DIFF
--- a/src/Textfield.js
+++ b/src/Textfield.js
@@ -11,6 +11,7 @@ class Textfield extends React.Component {
         expandable: PropTypes.bool,
         expandableIcon: PropTypes.string,
         floatingLabel: PropTypes.bool,
+        id: PropTypes.string,
         inputClassName: PropTypes.string,
         label: PropTypes.string.isRequired,
         maxRows: PropTypes.number,
@@ -48,51 +49,48 @@ class Textfield extends React.Component {
     }
 
     render() {
-        const { className, inputClassName,
+        const { className, inputClassName, id,
               error, expandable, expandableIcon,
               floatingLabel, label, maxRows,
               rows, style, ...otherProps } = this.props;
 
         const hasRows = !!rows;
-        const id = `textfield-${label.replace(/[^a-z0-9]/gi, '')}`;
+        const customId = id || `textfield-${label.replace(/[^a-z0-9]/gi, '')}`;
         const inputTag = hasRows || maxRows > 1 ? 'textarea' : 'input';
 
         const inputProps = {
             className: classNames('mdl-textfield__input', inputClassName),
-            id,
-            key: id,
+            id: customId,
             rows,
             ref: 'input',
             ...otherProps
         };
 
         const input = React.createElement(inputTag, inputProps);
-
-        const inputAndLabelError = [
-            input,
-            <label key="label" className="mdl-textfield__label" htmlFor={id}>{label}</label>,
-            error ? (
-                <span key="error" className="mdl-textfield__error">{error}</span>
-            ) : null
-        ];
+        const labelContainer = <label className="mdl-textfield__label" htmlFor={customId}>{label}</label>;
+        const errorContainer = !!error && <span className="mdl-textfield__error">{error}</span>;
 
         const containerClasses = classNames('mdl-textfield mdl-js-textfield', {
             'mdl-textfield--floating-label': floatingLabel,
             'mdl-textfield--expandable': expandable
         }, className);
 
-        const field = expandable
-            ? React.createElement('div', { className: 'mdl-textfield__expandable-holder' }, inputAndLabelError)
-            : inputAndLabelError;
-
-        return (
+        return expandable ? (
             <div className={containerClasses} style={style}>
-                {expandable ? (
-                    <label className="mdl-button mdl-js-button mdl-button--icon" htmlFor={id}>
-                        <i className="material-icons">{expandableIcon}</i>
-                    </label>
-                ) : null}
-                {field}
+                <label className="mdl-button mdl-js-button mdl-button--icon" htmlFor={customId}>
+                    <i className="material-icons">{expandableIcon}</i>
+                </label>
+                <div className="mdl-textfield__expandable-holder">
+                    {input}
+                    {labelContainer}
+                    {errorContainer}
+                </div>
+            </div>
+        ) : (
+            <div className={containerClasses} style={style}>
+                {input}
+                {labelContainer}
+                {errorContainer}
             </div>
         );
     }

--- a/src/__tests__/Textfield-test.js
+++ b/src/__tests__/Textfield-test.js
@@ -24,7 +24,7 @@ describe('Textfield', () => {
     it('should render an input by default', () => {
         const output = render(<Textfield label="label" />);
 
-        const input = output.props.children[1][0];
+        const [input] = output.props.children;
         expect(input.type).toBe('input');
     });
 
@@ -32,14 +32,14 @@ describe('Textfield', () => {
         it('when rows is specified', () => {
             const output = render(<Textfield label="label" rows={3} />);
 
-            const input = output.props.children[1][0];
+            const [input] = output.props.children;
             expect(input.type).toBe('textarea');
         });
 
         it('when maxRows is specified', () => {
             const output = render(<Textfield label="label" maxRows={5} />);
 
-            const input = output.props.children[1][0];
+            const [input] = output.props.children;
             expect(input.type).toBe('textarea');
         });
     });
@@ -54,15 +54,16 @@ describe('Textfield', () => {
     it('should not render any error message by default', () => {
         const output = render(<Textfield label="label" />);
 
-        expect(output.props.children[1][2]).toBe(null);
+        const [,, error] = output.props.children;
+        expect(error).toBe(false);
     });
 
     it('should render with an error message if specified', () => {
         const output = render(<Textfield label="label" error="error..." />);
 
-        expect(output.props.children[1][2].props.className)
-            .toInclude('mdl-textfield__error');
-        expect(output.props.children[1][2].props.children).toBe('error...');
+        const [,, error] = output.props.children;
+        expect(error.props.className).toInclude('mdl-textfield__error');
+        expect(error.props.children).toBe('error...');
     });
 
     it('should render an expandable textfield if specified', () => {


### PR DESCRIPTION
This will fix #197 (cc @aaugustin)

The key prop on the input was the cause of the issue. Because the key changed, React was removing the element, and adding a new one. But because the whole textfield was never removed from the DOM, the function `componentWillUnmount` on the `MDLComponent` was never called.

This codepen shows the fix in action: http://codepen.io/anon/pen/EPRLww
