### PR TITLE
feat: Add prop to hide the spacer element in the header

### DIFF
--- a/docs/pages/components/layout.md
+++ b/docs/pages/components/layout.md
@@ -273,7 +273,9 @@ class Demo extends React.Component {
 | Header    | transparent  | Boolean   | Makes header transparent | Optional |
 | Header    | waterfall    | Boolean   | Allows a "waterfall" effect with multiple header lines | Optional |
 | Header    | hideTop      | Boolean   | Hide the top part of the header when used with `waterfall` | Optional |
+| Header    | hideSpacer   | Boolean   | Removes the spacer from the header | Optional |
 | HeaderRow | title        | Any       | Set the layout title | Optional |
+| HeaderRow | hideSpacer   | Boolean   | Removes the spacer from the header | Optional |
 | Content   | component    | String, Element, Function   | Specify the custom component to use to render the element | Optional. Default 'div' |
 
 ### Footer

--- a/src/Layout/Header.js
+++ b/src/Layout/Header.js
@@ -5,7 +5,7 @@ import HeaderTabs from './HeaderTabs';
 
 const Header = props => {
     const { className, scroll, seamed, title, transparent,
-            waterfall, hideTop, children, ...otherProps } = props;
+            waterfall, hideTop, hideSpacer, children, ...otherProps } = props;
 
     const classes = classNames('mdl-layout__header', {
         'mdl-layout__header--scroll': scroll,
@@ -25,7 +25,7 @@ const Header = props => {
     return (
         <header className={classes} {...otherProps}>
             {isRowOrTab ? children : (
-                <HeaderRow title={title}>{children}</HeaderRow>
+                <HeaderRow title={title} hideSpacer={hideSpacer}>{children}</HeaderRow>
             )}
         </header>
     );
@@ -37,7 +37,8 @@ Header.propTypes = {
     title: PropTypes.node,
     transparent: PropTypes.bool,
     waterfall: PropTypes.bool,
-    hideTop: PropTypes.bool
+    hideTop: PropTypes.bool,
+    hideSpacer: PropTypes.bool
 };
 
 export default Header;

--- a/src/Layout/HeaderRow.js
+++ b/src/Layout/HeaderRow.js
@@ -3,21 +3,22 @@ import classNames from 'classnames';
 import Spacer from './Spacer';
 
 const HeaderRow = props => {
-    const { className, title, children, ...otherProps } = props;
+    const { className, title, children, hideSpacer, ...otherProps } = props;
 
     const classes = classNames('mdl-layout__header-row', className);
 
     return (
         <div className={classes} {...otherProps}>
             {title && <span className="mdl-layout-title">{title}</span>}
-            {title && <Spacer />}
+            {title && !hideSpacer && <Spacer />}
             {children}
         </div>
     );
 };
 HeaderRow.propTypes = {
     className: PropTypes.string,
-    title: PropTypes.node
+    title: PropTypes.node,
+    hideSpacer: PropTypes.bool
 };
 
 export default HeaderRow;

--- a/src/Layout/__tests__/HeaderRow-test.js
+++ b/src/Layout/__tests__/HeaderRow-test.js
@@ -45,5 +45,23 @@ describe('Layout', () => {
             expect(output.props.children[1]).toEqual(undefined);
             expect(output.props.children[2]).toEqual(<div>React-MDL</div>);
         });
+
+        it('should render a spacer if hideSpacer is set to false ', () => {
+            const output = render(<HeaderRow title="React-MDL" hideSpacer={false} />);
+
+            expect(output.props.children[1].type).toBe(Spacer);
+        });
+
+        it('should not render a spacer if hideSpacer is set to true ', () => {
+            const output = render(<HeaderRow title="React-MDL" hideSpacer><div>React-MDL</div></HeaderRow>);
+
+            expect(output.props.children[0].type).toBe('span');
+            expect(output.props.children[0].props.className)
+                .toBe('mdl-layout-title');
+            expect(output.props.children[0].props.children)
+                .toBe('React-MDL');
+            expect(output.props.children[1]).toNotBe(Spacer);
+            expect(output.props.children[2]).toEqual(<div>React-MDL</div>);
+        });
     });
 });


### PR DESCRIPTION
This pull request adds an option to hide the spacer element in the header. I updated the docs as well with this change. Default is still to output the spacer.

Let me know what you think.