### PR TITLE
Issue 267

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
     "coveralls": "^2.11.9",
+    "cross-env": "^1.0.7",
     "eslint": "^2.7.0",
     "eslint-config-airbnb": "^6.2.0",
     "eslint-plugin-react": "^4.3.0",
@@ -98,8 +99,8 @@
     "compile": "rimraf lib && babel src --ignore __tests__ --out-dir lib",
     "serve-docs": "cd docs && ./node_modules/.bin/gatsby develop",
     "build-docs": "cd docs && ./node_modules/.bin/gatsby build --prefix-links",
-    "build-umd": "NODE_ENV=production webpack src/index.js out/ReactMDL.js --output-library ReactMDL --output-library-target umd",
-    "build-min": "NODE_ENV=production webpack -p src/index.js out/ReactMDL.min.js --output-library ReactMDL --output-library-target umd",
+    "build-umd": "cross-env NODE_ENV=production webpack src/index.js out/ReactMDL.js --output-library ReactMDL --output-library-target umd",
+    "build-min": "cross-env NODE_ENV=production webpack -p src/index.js out/ReactMDL.min.js --output-library ReactMDL --output-library-target umd",
     "release": "./scripts/release.sh",
     "release-docs": "gh-pages -d docs/public/ -m 'Updates v'$npm_package_version"
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,17 @@
 module.exports = {
     externals: {
-        react: 'React',
-        'react-dom': 'ReactDOM'
+        react: {
+            root: 'React',
+            commonjs2: 'react',
+            commonjs: 'react',
+            amd: 'react'
+        },
+        'react-dom': {
+            root: 'ReactDOM',
+            commonjs2: 'react-dom',
+            commonjs: 'react-dom',
+            amd: 'react-dom'
+		}
     },
     devtool: 'sourcemap',
     module: {


### PR DESCRIPTION
This PR addresses two issues:

* Build does not work on Windows #300
* Dependency names wrong when using React MDL from script #298

I've ran the build and the new UMD header looks like this:

```js
(function webpackUniversalModuleDefinition(root, factory) {
	if(typeof exports === 'object' && typeof module === 'object')
		module.exports = factory(require("react"), require("react-dom"));
	else if(typeof define === 'function' && define.amd)
		define(["react", "react-dom"], factory);
	else if(typeof exports === 'object')
		exports["ReactMDL"] = factory(require("react"), require("react-dom"));
	else
		root["ReactMDL"] = factory(root["React"], root["ReactDOM"]);
})(this, function(__WEBPACK_EXTERNAL_MODULE_2__, __WEBPACK_EXTERNAL_MODULE_4__) {
```