### PR TITLE
Allow to prevent auto-upgrade of components on load

### DIFF
--- a/extra/material.js
+++ b/extra/material.js
@@ -58,8 +58,10 @@ var componentHandler = {
    */
   upgradeElements: function(elements) {},
   /**
-   * Upgrades all registered components found in the current DOM. This is
-   * automatically called on window load.
+   * Upgrades all registered components found in the current DOM.
+   * This is automatically called on window load, unless the flag
+   * `mdlSuppressAutoUpgrade` is present on `window` and has a truthy
+   * value, in which case you should invoke this function youself.
    */
   upgradeAllRegistered: function() {},
   /**
@@ -471,7 +473,6 @@ window['componentHandler'] = componentHandler;
 
 window.addEventListener('load', function() {
   'use strict';
-
   /**
    * Performs a "Cutting the mustard" test. If the browser supports the features
    * tested, adds a mdl-js class to the <html> element. It then upgrades all MDL
@@ -481,7 +482,10 @@ window.addEventListener('load', function() {
       'querySelector' in document &&
       'addEventListener' in window && Array.prototype.forEach) {
     document.documentElement.classList.add('mdl-js');
-    componentHandler.upgradeAllRegistered();
+
+    if (! window.mdlSuppressAutoUpgrade) {
+      componentHandler.upgradeAllRegistered();
+    }
   } else {
     /**
      * Dummy function to avoid JS errors.
@@ -491,6 +495,10 @@ window.addEventListener('load', function() {
      * Dummy function to avoid JS errors.
      */
     componentHandler.register = function() {};
+    /**
+     * Dummy function to avoid JS errors.
+     */
+    componentHandler.upgradeAllRegistered = function() {};
   }
 });
 

--- a/extra/material.js
+++ b/extra/material.js
@@ -59,9 +59,6 @@ var componentHandler = {
   upgradeElements: function(elements) {},
   /**
    * Upgrades all registered components found in the current DOM.
-   * This is automatically called on window load, unless the flag
-   * `mdlSuppressAutoUpgrade` is present on `window` and has a truthy
-   * value, in which case you should invoke this function youself.
    */
   upgradeAllRegistered: function() {},
   /**
@@ -473,6 +470,7 @@ window['componentHandler'] = componentHandler;
 
 window.addEventListener('load', function() {
   'use strict';
+
   /**
    * Performs a "Cutting the mustard" test. If the browser supports the features
    * tested, adds a mdl-js class to the <html> element. It then upgrades all MDL
@@ -482,10 +480,6 @@ window.addEventListener('load', function() {
       'querySelector' in document &&
       'addEventListener' in window && Array.prototype.forEach) {
     document.documentElement.classList.add('mdl-js');
-
-    if (! window.mdlSuppressAutoUpgrade) {
-      componentHandler.upgradeAllRegistered();
-    }
   } else {
     /**
      * Dummy function to avoid JS errors.
@@ -495,10 +489,6 @@ window.addEventListener('load', function() {
      * Dummy function to avoid JS errors.
      */
     componentHandler.register = function() {};
-    /**
-     * Dummy function to avoid JS errors.
-     */
-    componentHandler.upgradeAllRegistered = function() {};
   }
 });
 


### PR DESCRIPTION
Code now checks whether `window.mdlSuppressAutoUpgrade` is truthy and if so, skips auto upgrade.
SEE: data-upgraded causes Warning: React attempted to reuse markup in a container but the checksum was invalid #302 

This change allowed me to set a flag to prevent the auto-upgrade, which makes the issue go away.

Here is the surprise: I expected that I would have to call `upgradeAllRegistered` myself, but actually my app seems to be working just fine without that call. I suspect this is because React MDL already upgrades / downgrades all components when mounting / unmounting.  So probably, we can make this change even simpler and just remove the line that calls `upgradeAllRegistered` from the onload handler altogether. However to make this PR more acceptable, I opted not to do that and instead just use the flag. This will make sure that no one is affected by this change that does not specify this flag. 

We can always remove the flag later after more testing I think.