### PR TITLE
if child element has id, Tooltip use this

### DIFF
--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -4,7 +4,7 @@ import MDLComponent from './utils/MDLComponent';
 
 const Tooltip = (props) => {
     const { label, large, children, position, ...otherProps } = props;
-    const id = Math.random().toString(36).substr(2);
+    let id = Math.random().toString(36).substr(2);
 
     const newLabel = (typeof label === 'string')
         ? <span>{label}</span>
@@ -15,6 +15,7 @@ const Tooltip = (props) => {
         element = <span>{children}</span>;
     } else {
         element = React.Children.only(children);
+        id = element.props.id || id
     }
 
     return (

--- a/src/__tests__/Tooltip-test.js
+++ b/src/__tests__/Tooltip-test.js
@@ -45,6 +45,21 @@ describe('Tooltip', () => {
         expect(child.props.id).toBe(label.props.htmlFor);
     });
 
+    it('should use the id of child if this have', () => {
+        const element = (
+            <Tooltip label="my tooltip">
+                <div id="test_id">text</div>
+            </Tooltip>
+        );
+        const output = render(element);
+
+        const child = output.props.children[0];
+        const label = output.props.children[1].props.children;
+
+
+        expect(child.props.id).toBe(label.props.htmlFor);
+    });
+
     it('should work with a complex child', () => {
         const element = (
             <Tooltip label={<div>my tooltip</div>}>


### PR DESCRIPTION
This patch is a child element's id will be used for Tooltip component("for" attribute)

(I think you might know this already)
Background & Problem:
When server-side rendering, React will calculate the checksum from the elements .
if Tooltip components randomly generate id, redrawing will occur always on the client side.
