### PR TITLE
feat(Grid): allow cells to be grids, too, and have subcells

### DIFF
--- a/docs/pages/components/grid.md
+++ b/docs/pages/components/grid.md
@@ -54,3 +54,5 @@ title: Grid
 | Cell      | phone        | Number[1..12]    | Set the column size in phone mode | Optional |
 | Cell      | tablet       | Number[1..12]    | Set the column size in tablet mode | Optional |
 | Cell      | shadow       | Number    | Defines the shadow depth | Optional, Default 0. Must be between 0 and 6 |
+| Cell      | grid         | Boolean   | Make this cell a grid, too | Optional |
+| Cell      | noSpacing    | Boolean   | Removes the margins between the subcells. | Optional, ignored if `grid` is not set |

--- a/src/Grid/Cell.js
+++ b/src/Grid/Cell.js
@@ -17,12 +17,15 @@ const propTypes = {
     hideDesktop: PropTypes.bool,
     hidePhone: PropTypes.bool,
     hideTablet: PropTypes.bool,
-    shadow: PropTypes.number
+    shadow: PropTypes.number,
+    grid: PropTypes.bool,
+    noSpacing: PropTypes.bool
 };
 
 const Cell = (props) => {
     const { align, className, children, col, phone, tablet, component,
-        hideDesktop, hidePhone, hideTablet, shadow, ...otherProps } = props;
+        hideDesktop, hidePhone, hideTablet, shadow, grid, noSpacing,
+        ...otherProps } = props;
 
     const hasShadow = typeof shadow !== 'undefined';
     const shadowLevel = clamp(shadow || 0, 0, shadows.length - 1);
@@ -35,7 +38,9 @@ const Cell = (props) => {
         'mdl-cell--hide-desktop': hideDesktop,
         'mdl-cell--hide-phone': hidePhone,
         'mdl-cell--hide-tablet': hideTablet,
-        [shadows[shadowLevel]]: hasShadow
+        [shadows[shadowLevel]]: hasShadow,
+        'mdl-grid': grid,
+        'mdl-grid--no-spacing': grid && noSpacing
     }, className);
 
     return React.createElement(component || 'div', {


### PR DESCRIPTION
A div can be both mdl-cell and mdl-grid, in which case it is a cell that can contain subcells.

See e.g. [mdl dashboard template](https://getmdl.io/templates/dashboard/index.html)