### PR TITLE
fix(Snackbar): Prevent unknown prop warning

### DIFF
--- a/src/Snackbar.js
+++ b/src/Snackbar.js
@@ -76,6 +76,9 @@ class Snackbar extends React.Component {
             'mdl-snackbar--active': open
         }, className);
 
+        delete otherProps.onTimeout;
+        delete otherProps.timeout;
+
         return (
             <div ref="snackbar" className={classes} aria-hidden={!open} {...otherProps}>
                 <div className="mdl-snackbar__text">{active && children}</div>


### PR DESCRIPTION
delete onTimeout and timeout from otherProps to prevent warning.