### PR TITLE
Including docs on Tab parameters

### DIFF
--- a/components/tabs/index.html
+++ b/components/tabs/index.html
@@ -137,6 +137,34 @@ var Demo = function (_React$Component) {
 <td style="text-align:left">Pass Props to the TabBar Element</td>
 <td style="text-align:left">Optional</td>
 </tr>
+<tr>
+<td style="text-align:left">Tab</td>
+<td style="text-align:left">active</td>
+<td style="text-align:left">bool</td>
+<td style="text-align:left">If this is the active tab</td>
+<td style="text-align:left">Optional</td>
+</tr>
+<tr>
+<td style="text-align:left">Tab</td>
+<td style="text-align:left">component</td>
+<td style="text-align:left">string | element | function</td>
+<td style="text-align:left">Passing a tag/component here overrides the default <code>a</code> tag it renders.</td>
+<td style="text-align:left">Optional</td>
+</tr>
+<tr>
+<td style="text-align:left">Tab</td>
+<td style="text-align:left">onTabClick</td>
+<td style="text-align:left">function(tabId)</td>
+<td style="text-align:left">If present, this function is bound to the onClick event on the Tab.</td>
+<td style="text-align:left">Optional</td>
+</tr>
+<tr>
+<td style="text-align:left">Tab</td>
+<td style="text-align:left">tabId</td>
+<td style="text-align:left">number</td>
+<td style="text-align:left">If present, will override the default tab identification number.</td>
+<td style="text-align:left">Optional</td>
+</tr>
 </tbody>
 </table>
 </div></div></div></div></div></div></div></div></div></div><script src="/react-mdl/bundle.js"></script><script>


### PR DESCRIPTION
With this present we can close #355, as there's a feature that solves that issue but was not documented.