### PR TITLE
Allow iterables as prop types similar to react core.

### DIFF
--- a/src/DataTable/Selectable.js
+++ b/src/DataTable/Selectable.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import getIteratorFn from 'react/lib/getIteratorFn';
 import classNames from 'classnames';
 import isEqual from 'lodash.isequal';
 import TableHeader from './TableHeader';
@@ -13,9 +14,15 @@ const propTypes = {
     ),
     onSelectionChanged: PropTypes.func,
     rowKeyColumn: PropTypes.string,
-    rows: PropTypes.arrayOf(
-        PropTypes.object
-    ).isRequired,
+    rows: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.object),
+        (props, propName, componentName) => {
+            if (!getIteratorFn(props[propName])) {
+                return new Error(`Invalid prop \`${propName}\` supplied to ${componentName}. Validation failed.`);
+            }
+            return undefined;
+        },
+    ]).isRequired,
     selectable: PropTypes.bool
 };
 

--- a/src/DataTable/Sortable.js
+++ b/src/DataTable/Sortable.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import getIteratorFn from 'react/lib/getIteratorFn';
 import classNames from 'classnames';
 import TableHeader from './TableHeader';
 
@@ -17,9 +18,15 @@ const propTypes = {
     data: (props, propName, componentName) => (
         props[propName] && new Error(`${componentName}: \`${propName}\` is deprecated, please use \`rows\` instead. \`${propName}\` will be removed in the next major release.`)
     ),
-    rows: PropTypes.arrayOf(
-        PropTypes.object
-    ).isRequired,
+    rows: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.object),
+        (props, propName, componentName) => {
+            if (!getIteratorFn(props[propName])) {
+                return new Error(`Invalid prop \`${propName}\` supplied to ${componentName}. Validation failed.`);
+            }
+            return undefined;
+        },
+    ]).isRequired,
     sortable: PropTypes.bool
 };
 

--- a/src/DataTable/Table.js
+++ b/src/DataTable/Table.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import getIteratorFn from 'react/lib/getIteratorFn';
 import classNames from 'classnames';
 import clamp from 'clamp';
 import shadows from '../utils/shadows';
@@ -15,9 +16,15 @@ const propTypes = {
         props[propName] && new Error(`${componentName}: \`${propName}\` is deprecated, please use \`rows\` instead. \`${propName}\` will be removed in the next major release.`)
     ),
     rowKeyColumn: PropTypes.string,
-    rows: PropTypes.arrayOf(
-        PropTypes.object
-    ).isRequired,
+    rows: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.object),
+        (props, propName, componentName) => {
+            if (!getIteratorFn(props[propName])) {
+                return new Error(`Invalid prop \`${propName}\` supplied to ${componentName}. Validation failed.`);
+            }
+            return undefined;
+        },
+    ]).isRequired,
     shadow: PropTypes.number
 };
 


### PR DESCRIPTION
See issue #359.

Uses react's [getIteratorFn()](https://github.com/facebook/react/blob/v15.3.0/src/shared/utils/getIteratorFn.js) to check weather the passed prop can be iterated. Currently I do not check for valid child items.. Not sure whether that's required? Would cause quite a bit of overhead.

Side note: Does this make sense for any other react-mdl component? Did not find anything where immutable (or similar) props make sense.