### PR TITLE
Clarify docs for `DataTable`'s `shadow` prop

### DIFF
--- a/docs/pages/components/datatable.md
+++ b/docs/pages/components/datatable.md
@@ -84,4 +84,4 @@ title: DataTable
 | rowKeyColumn | String    | Will define the `key` for each row based on the content of the column specified (will often be `id` or `uid`) | Optional, but recommended |
 | rows       | Array of object   | Set the rows data | Required. The properties of each object should be the "name" of each column |
 | selectable | Boolean | Adds checkboxes in front of each rows to select it | Optional. |
-| shadow       | Number    | Defines the shadow depth | Optional, Default 0. Must be between 0 and 6 |
+| shadow       | Number    | Defines the shadow depth | Optional. If provided, must be between 0 and 6 inclusive. If omitted, table will not have any shadow. |


### PR DESCRIPTION
The documentation around the `DataTable`'s `shadow` prop indicated that its
default value was 0. However, omitting the `shadow` prop and setting it to `0`
produced different results-- the former produced no shadow, while the latter
added a class of `"mdl-shadow--2dp"` to the table. This commit clarifies the
documentation.