### PR TITLE
Replace npmcdn with unpkg

### DIFF
--- a/docs/html.js
+++ b/docs/html.js
@@ -26,8 +26,8 @@ const DocHtml = props => {
                 <title>{title}</title>
                 {props.favicon && <link rel="shortcut icon" href={props.favicon} />}
                 <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons" />
-                <script src="https://npmcdn.com/dialog-polyfill/dialog-polyfill.js"></script>
-                <link rel="stylesheet" type="text/css" href="https://npmcdn.com/dialog-polyfill/dialog-polyfill.css" />
+                <script src="https://unpkg.com/dialog-polyfill/dialog-polyfill.js"></script>
+                <link rel="stylesheet" type="text/css" href="https://unpkg.com/dialog-polyfill/dialog-polyfill.css" />
                 {cssLink}
             </head>
             <body>

--- a/docs/loaders/markdown-loader/render-codepen-button.js
+++ b/docs/loaders/markdown-loader/render-codepen-button.js
@@ -1,13 +1,13 @@
 const jsExternal = [
-    'https://npmcdn.com/react/dist/react.js',
-    'https://npmcdn.com/react-dom/dist/react-dom.js',
-    'https://npmcdn.com/react-mdl/extra/material.js',
-    'https://npmcdn.com/react-mdl/out/ReactMDL.js',
-    'https://npmcdn.com/dialog-polyfill/dialog-polyfill.js'
+    'https://unpkg.com/react/dist/react.js',
+    'https://unpkg.com/react-dom/dist/react-dom.js',
+    'https://unpkg.com/react-mdl/extra/material.js',
+    'https://unpkg.com/react-mdl/out/ReactMDL.js',
+    'https://unpkg.com/dialog-polyfill/dialog-polyfill.js'
 ];
 const cssExternal = [
-    'https://npmcdn.com/react-mdl/extra/material.css',
-    'https://npmcdn.com/dialog-polyfill/dialog-polyfill.css'
+    'https://unpkg.com/react-mdl/extra/material.css',
+    'https://unpkg.com/dialog-polyfill/dialog-polyfill.css'
 ];
 
 function getSimpleDemoCode(jsxCode) {


### PR DESCRIPTION
Hello.

As you might have heard, npmcdn is in the migration process and will be deprecated soon.
A new address is the https://unpkg.com/

Hope this will be useful.