### PR TITLE
Add instructions for Create React App

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ If you're worried about the changes we made, you can take a look at the [patch n
 <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 ```
 
+This won’t work if you use [Create React App](https://github.com/facebookincubator/create-react-app) with `react-scripts` higher than `0.4.0`.  
+If you use it, don’t modify your HTML but instead put these lines in your `src/index.js`:
+
+```js
+import 'react-mdl/extra/material.css';
+import 'react-mdl/extra/material.js';
+```
+
 ## Installation
 
 `npm install --save react-mdl`

--- a/README.md
+++ b/README.md
@@ -14,8 +14,16 @@ If you're worried about the changes we made, you can take a look at the [patch n
 <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
 ```
 
-This won’t work if you use [Create React App](https://github.com/facebookincubator/create-react-app) with `react-scripts` higher than `0.4.0`.  
-If you use it, don’t modify your HTML but instead put these lines in your `src/index.js`:
+### Create React App
+
+The above instructions won’t work if you use [Create React App](https://github.com/facebookincubator/create-react-app) with `react-scripts` higher than `0.4.0`.  
+If you use it, add only this one line to your HTML:
+
+```html
+<link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+```
+
+Then add these lines to `src/index.js`:
 
 ```js
 import 'react-mdl/extra/material.css';


### PR DESCRIPTION
Please see https://github.com/facebookincubator/create-react-app/issues/564 for the reference.
It is an increasingly popular way of creating apps so it’d be great to mention this incompatibility.