### PR TITLE
fixed interaction between IconToggle and Tooltip

### DIFF
--- a/src/IconToggle.js
+++ b/src/IconToggle.js
@@ -9,6 +9,7 @@ const propTypes = {
     checked: PropTypes.bool,
     className: PropTypes.string,
     disabled: PropTypes.bool,
+    id: PropTypes.string,
     name: PropTypes.string.isRequired,
     onChange: PropTypes.func,
     ripple: PropTypes.bool

--- a/src/IconToggle.js
+++ b/src/IconToggle.js
@@ -26,14 +26,14 @@ class IconToggle extends React.Component {
     }
 
     render() {
-        const { className, name, ripple, ...inputProps } = this.props;
+        const { className, name, ripple, id, ...inputProps } = this.props;
 
         const classes = classNames('mdl-icon-toggle mdl-js-icon-toggle', {
             'mdl-js-ripple-effect': ripple
         }, className);
 
         return (
-            <label className={classes}>
+            <label className={classes} id={id}>
                 <input
                     type="checkbox"
                     className="mdl-icon-toggle__input"


### PR DESCRIPTION
The MDL Tooltip component uses the ID to find the element to attach the mouse events to.

IconToggle was putting the passed ID prop on the child, invisible input element, as opposed to the visible parent. This meant that you were not able to nest an IconToggle within a Tooltip.

This fix adds the ID to the parent instead, allowing the tooltip work.